### PR TITLE
Separate concept of "not installing something" and "not running a lifecycle-action for something already installed".

### DIFF
--- a/lib/quill/composer/dependencies.js
+++ b/lib/quill/composer/dependencies.js
@@ -136,7 +136,8 @@ exports.runlist = function (options, callback) {
 
       var record = {
         name: name,
-        semver: required
+        semver: required,
+        scripts: system.scripts
       };
       
       record.version = semver.maxSatisfying(
@@ -196,16 +197,11 @@ exports.runlist = function (options, callback) {
   }
   
   async.forEachSeries(exports.systemNames(systems), updateList, function (err) {
-    if (err) {
-      return callback(err);
-    }
-    
-    callback(null, list.map(function (record) {
-      return [record.name, record.version].join('@');
-    }));
+    return err
+      ? callback(err)
+      : callback(null, list);
   });
 };
-
 
 //
 // ### function localizeRunlist (options)
@@ -214,31 +210,124 @@ exports.runlist = function (options, callback) {
 //
 // Localizes the specified `runlist` removing any systems already installed.
 //
-exports.localizeRunlist = function (runlist, callback) {
-  async.waterfall([
-    //
-    // 1. Get all of the installed packages.
-    //
-    async.apply(composer.installed.list),
-    //
-    // 2. Reduce the list for anything already installed
-    //
-    // Remark: This is probably an overly simple algorithm
-    //
-    function (installed, next) {
-      if (!installed) {
-        return next(null, runlist);
+exports.localizeRunlist = function (runlist, installed) {
+  if (!installed) {
+    return runlist;
+  }
+
+  //
+  // Reduce the list for anything already installed
+  //
+  return runlist.map(function (system) {
+    if (installed[system.name]) {
+      quill.log.warn('Skipping installed dependency: ' + system.name.magenta);
+    }
+
+    return !installed[system.name] ? system : null;
+  }).filter(Boolean));
+};
+
+//
+// ### function expandRunlist (runlist, script, callback)
+// #### @action {string} Action being run on the expanded runlist.
+// #### @runlist {Array} List of systems to create runlist for.
+// #### @installed {Object} Information about installed systems.
+//
+// Expands the specified `runlist` into a set of scripts to be run
+// for the set of systems.
+//
+exports.expandRunlist = function (action, runlist, installed) {
+  var previous = composer.orderings[action]
+      matchers = [new RegExp(action, 'i')];
+
+  //
+  // Create matchers for lifecycle actions for which
+  // this `action` is dependent.
+  //
+  previous = previous.map(function (str) {
+    return new RegExp(str, 'i');
+  });
+
+  matchers = matchers.concat(previous);
+
+  //
+  // 1. Filter the set of scripts for the system to only include
+  // those required by the specified `action`.
+  //
+  runlist = runlist.map(function (system) {
+    if (Array.isArray(system.scripts)) {
+      system.scripts = system.scripts.filter(function (script) {
+        return matchers.some(function (re) {
+          return re.test(script);
+        });
+      });
+    }
+
+    return system;
+  });
+
+  //
+  // 2. Reduce the list of scripts for anything already installed
+  // based on the history on the local machine.
+  //
+  if (installed) {
+    runlist = runlist.map(function (system) {
+      if (!installed[system.name])
+        return system;
       }
 
-      next(null, runlist.map(function (system) {
-        if (installed[system.name]) {
-          quill.log.warn('Skipping installed dependency: ' + system.name.magenta);
+      function logSkip(script) {
+        quill.log.warn([
+          'Skipping previous lifecycle action',
+          script.yellow,
+          'for',
+          system.name.magenta
+        ].join(' '));
+      }
+
+      //
+      // Remove the install script since this system is already
+      // installed
+      //
+      logSkip('install');
+      system.scripts = system.scripts.filter(function (script) {
+        return !/install/.test(script);
+      });
+
+      var history = installed[system.name].history || {},
+          actions;
+
+      actions = Object.keys(history).map(function (key) {
+        return history[key].action;
+      });
+
+      //
+      // If there is no history, return all the scripts
+      // for the system.
+      //
+      if (!actions.length) {
+        return system;
+      }
+
+      //
+      // Now filter out any dependent scripts for the action
+      // e.g. for `start`, remove `configure` and `install`.
+      //
+      system.scripts = system.scripts.filter(function (script) {
+        var alreadyRun = previous.some(function (re) {
+          return re.test(script);
+        });
+
+        if (alreadyRun) {
+          logSkip(script);
         }
 
-        return !installed[system.name] ? system : null;
-      }).filter(Boolean));
-    }
-  ], callback);
+        return !alreadyRun;
+      });
+    });
+  }
+
+  return runlist;
 };
 
 //

--- a/lib/quill/composer/dependencies.js
+++ b/lib/quill/composer/dependencies.js
@@ -5,7 +5,8 @@
  *
  */
 
-var common = require('flatiron').common,
+var path = require('path'),
+    common = require('flatiron').common,
     async = common.async,
     semver = require('semver'),
     composer = require('./index'),
@@ -219,12 +220,14 @@ exports.localizeRunlist = function (runlist, installed) {
   // Reduce the list for anything already installed
   //
   return runlist.map(function (system) {
-    if (installed[system.name]) {
-      quill.log.warn('Skipping installed dependency: ' + system.name.magenta);
+    if (installed[system.name] && installed[system.name].system) {
+      quill.log.info('Already installed: ' + system.name.magenta);
     }
 
-    return !installed[system.name] ? system : null;
-  }).filter(Boolean));
+    return !installed[system.name] || !installed[system.name].system
+      ? system
+      : null;
+  }).filter(Boolean);
 };
 
 //
@@ -237,15 +240,15 @@ exports.localizeRunlist = function (runlist, installed) {
 // for the set of systems.
 //
 exports.expandRunlist = function (action, runlist, installed) {
-  var previous = composer.orderings[action]
-      matchers = [new RegExp(action, 'i')];
+  var previous = composer.orderings[action] || [],
+      matchers = [new RegExp('^' + action, 'i')];
 
   //
   // Create matchers for lifecycle actions for which
   // this `action` is dependent.
   //
   previous = previous.map(function (str) {
-    return new RegExp(str, 'i');
+    return new RegExp('^' + str, 'i');
   });
 
   matchers = matchers.concat(previous);
@@ -272,13 +275,13 @@ exports.expandRunlist = function (action, runlist, installed) {
   //
   if (installed) {
     runlist = runlist.map(function (system) {
-      if (!installed[system.name])
+      if (!installed[system.name] || !installed[system.name].system) {
         return system;
       }
 
       function logSkip(script) {
-        quill.log.warn([
-          'Skipping previous lifecycle action',
+        quill.log.info([
+          'Already executed lifecycle action',
           script.yellow,
           'for',
           system.name.magenta
@@ -291,7 +294,7 @@ exports.expandRunlist = function (action, runlist, installed) {
       //
       logSkip('install');
       system.scripts = system.scripts.filter(function (script) {
-        return !/install/.test(script);
+        return !/^install/.test(script);
       });
 
       var history = installed[system.name].history || {},
@@ -324,6 +327,8 @@ exports.expandRunlist = function (action, runlist, installed) {
 
         return !alreadyRun;
       });
+
+      return system;
     });
   }
 

--- a/lib/quill/composer/lifecycle.js
+++ b/lib/quill/composer/lifecycle.js
@@ -14,6 +14,14 @@ var fs = require('fs'),
     composer = require('./index'),
     quill = require('../../quill');
 
+exports.orderings = {
+  install:   null,
+  uninstall: null,
+  configure: ['install'],
+  update:    ['install', 'configure'],
+  start:     ['install', 'configure']
+};
+
 //
 // ### function install (runlist, callback)
 // #### @runlist {Array} Systems to run install lifecycle script for.
@@ -84,28 +92,49 @@ exports.uninstall = function (runlist, callback) {
 // on the current machine.
 //
 exports.run = function (script, runlist, callback) {
+  var installed;
+
   //
   // Helper function which runs a specified lifecycle `script`
   // on all necessary systems. 
   //
   function runAll(runlist) {
-    async.forEachSeries(runlist, exports.runOne.bind(null, script), function (err) {
+    async.forEachSeries(runlist, exports.runScripts, function (err) {
       return err
         ? callback(err)
         : callback(null, runlist);
     });
   }
 
-  function maybeLocalizeRunlist(systems, callback) {
-    if (script === 'install' && quill.argv.force) {
-      return callback(null, systems);
-    }
-    else {
-      return composer.localizeRunlist(systems, callback);
-    }
+  //
+  // ### function installSystems(systems)
+  // Adds all of the necessary systems to the quill installed
+  // directory.
+  //
+  function installSystems(systems) {
+    async.waterfall([
+      async.apply(composer.installed.list),
+      function maybeLocalizeRunlist(installed_, next) {
+        installed = installed_;
+
+        return script === 'install' && quill.argv.force
+          ? next(null, systems)
+          : next(null, composer.localizeRunlist(systems, installed));
+      },
+      composer.installed.add
+    ], function (err) {
+      return !err
+        ? runAll(composer.expandRunlist(script, systems, installed));
+        : callback(err);
+    });
   }
 
-  function doRun() {
+  //
+  // ### function cacheSystems()
+  // Adds all of the necessary systems to the quill cache
+  // directory.
+  //
+  function cacheSystems() {
     async.waterfall([
       wtfos,
       function (os, callback) {
@@ -114,11 +143,12 @@ exports.run = function (script, runlist, callback) {
           os: (os.distribution && os.distribution.toLowerCase()) || null
         });
       },
-      composer.cache.add,
-      maybeLocalizeRunlist,
-      composer.installed.add,
-      runAll
-    ], callback);
+      composer.cache.add
+    ], function (err, systems) {
+      return err
+        ? callback(err)
+        : installSystems(systems)
+    });
   }
 
   if (script === 'install' && quill.argv.force) {
@@ -126,9 +156,9 @@ exports.run = function (script, runlist, callback) {
     // Special case: when we're installing system which is already installed,
     // run uninstall script for the installed version first.
     //
-    composer.installed.list(function (err, installed) {
+    return composer.installed.list(function (err, installed) {
       if (err || !installed) {
-        return doRun();
+        return cacheSystems();
       }
 
       async.forEachSeries(Object.keys(installed), function (system, next) {
@@ -140,123 +170,83 @@ exports.run = function (script, runlist, callback) {
           ? exports.runOne('uninstall', installed[system].system, next)
           : next();
       }, function () {
-        composer.installed.remove(runlist, doRun);
+        composer.installed.remove(runlist, cacheSystems);
       });
     });
   }
-  else {
-    doRun();
-  }
+
+  cacheSystems();
 };
 
 //
-// ### function runOne (script, system, callback)
-// #### @script {string} Name of the lifecycle script to execute.
-// #### @system {string|Object} System to run lifecycle script for.
+// ### function runScripts (script, system, callback)
+// #### @system {Object} System to run lifecycle script for.
 // #### @callback {function} Continuation to respond to when complete.
 //
-// Executes the lifecycle `script` against the target `system` 
-// on the current machine.
+// Executes all lifecycle `scripts` in `system.scripts` for the target
+// `system` on the current machine.
 //
-exports.runOne = function (script, system, callback) {
+exports.runScripts = function (system, callback) {
   var responded = false,
       config,
       target,
       child;
 
   //
-  // Ensure that previous lifecycle actions have occured.
-  // https://github.com/nodejitsu/quill/issues/13
+  // Get the configuration for the specified system and then
+  // run all scripts in `system.scripts`.
   //
-  function ensureInstalled() {
-    composer.history.read(system, function (err, history) {
-      if (err) {
-        return callback(err);
-      }
-
-      var actions;
-
-      history = history || {};
-      actions = Object.keys(history).map(function (key) {
-        return history[key].action;
-      });
-
-      if (['install', 'uninstall'].indexOf(script) === -1) {
-        async.series([
-          function install(next) {
-            return actions.indexOf('install') === -1
-              ? exports.runOne('install', system, next)
-              : next();
-          },
-          function configure(next) {
-            return actions.indexOf('configure') === -1 && script !== 'configure'
-              ? exports.runOne('configure', system, next)
-              : next();
-          }
-        ], getConfig);
-      }
-      else {
-        getConfig();
-      }
-    });
-  }
-
-  function getConfig(err) {
+  composer.config.getConfig(system, function (err, config) {
     if (err) {
-      return callback(err);
+      return callback(err, true, true);
+    }
+    else if (!Array.isArray(system.scripts)) {
+      return callback(new Error('No scripts found in: ' + system.path.yellow), true, true);
     }
 
-    composer.config.getConfig(system, function (err, config_) {
-      if (err) {
-        return callback(err, true, true);
-      }
+    async.forEachSeries(
+      system.scripts,
+      function run(script, next) {
+        exports.run(script, system, config, next);
+      },
+      callback
+    );
+  });
+};
 
-      config = config_;
-      template();
-    });
-  }
-
+//
+// ### function runOne (script, system, config, callback)
+// #### @script {string} Script to execute for the system.
+// #### @system {Object} System to run lifecycle script for.
+// #### @config {Object} Configuration to use when running the script.
+// #### @callback {function} Continuation to respond to when complete.
+//
+// Executes the lifecycle `script` for the target `system` using
+// the given `config` on the current machine.
+//
+exports.runOne = function (script, system, config, callback) {
   //
-  // Template all system's files.
+  // ### function run(err)
+  // Helper function which executes the specified script
+  // for the system.
   //
-  function template() {
-    if (script !== 'configure' || quill.config.get('template') === false) {
-      return run();
-    }
-
-    composer.template.dir({
-      dir: path.join(system.path, 'templates'),
-      config: config,
-      force: quill.argv.force
-    }, run);
-  }
-
   function run(err) {
     if (err) {
       return callback(err);
     }
 
+    var target = path.join(system.path, 'scripts', script);
+
     //
     // Read all the files from the system's `scripts` directory, fetch the
     // target script and execute it. Pipe all `data` events to `quill.emit`.
     //
-    fs.readdir(path.join(system.path, 'scripts'), function (err, files) {
+    fs.stat(target, function (err, stats) {
       if (err) {
-        return callback(err);
+        return err.code !== 'ENOENT'
+          ? callback(err)
+          : callback();
       }
-
-      target = files.filter(function (file) {
-        return file.replace(path.extname(file), '') === script;
-      })[0];
-
-      if (!target) {
-        //
-        // Remark: Should there be an error here?
-        //
-        return callback();
-      }
-
-      target = path.join(system.path, 'scripts', target);
 
       //
       // Remark: Need to ensure the script is executable.
@@ -333,5 +323,20 @@ exports.runOne = function (script, system, callback) {
       : callback(null);
   }
 
-  ensureInstalled();
+  //
+  // If the `script` is not "configure" then just
+  // run the script.
+  //
+  if (script !== 'configure' || quill.config.get('template') === false) {
+    return run();
+  }
+
+  //
+  // Template all system's files then run the script.
+  //
+  composer.template.dir({
+    dir: path.join(system.path, 'templates'),
+    config: config,
+    force: quill.argv.force
+  }, run);
 };

--- a/lib/quill/composer/lifecycle.js
+++ b/lib/quill/composer/lifecycle.js
@@ -341,8 +341,8 @@ exports.runOne = function (script, system, config, callback) {
       //
       // Setup event handlers for the child process.
       //
-      child.stdout.on('data', quill.emit.bind(quill, ['run', script, 'stdout'], system));
-      child.stderr.on('data', quill.emit.bind(quill, ['run', script, 'stderr'], system));
+      child.stdout.on('data', quill.emit.bind(quill, ['run', action, 'stdout'], system));
+      child.stderr.on('data', quill.emit.bind(quill, ['run', action, 'stderr'], system));
       child.on('error', done);
       child.on('exit', function (code) {
         //

--- a/lib/quill/composer/lifecycle.js
+++ b/lib/quill/composer/lifecycle.js
@@ -14,12 +14,56 @@ var fs = require('fs'),
     composer = require('./index'),
     quill = require('../../quill');
 
+//
+// ### @orderings {Object}
+// Ordering of lifecycle-actions
+//
 exports.orderings = {
   install:   null,
   uninstall: null,
   configure: ['install'],
   update:    ['install', 'configure'],
   start:     ['install', 'configure']
+};
+
+//
+// ### @private sortScript (scripts)
+// Returns scripts based on custom sort-ordering
+// for lifecycle actions.
+//
+// TODO: Not make this so massively inefficient.
+//
+function sortScripts(scripts) {
+  var has = {
+    updateOrStart: scripts.filter(function (script) {
+      return /^(update|start)/.test(script);
+    }),
+    configure: scripts.filter(function (script) {
+      return /^configure/.test(script);
+    })
+  };
+
+  if (has.updateOrStart.length) {
+    return [
+      /^install/,
+      /^configure/,
+      /^(update|start)/
+    ].map(function (re) {
+      return scripts
+        .filter(function (s) { return re.test(s); })[0];
+    }).filter(Boolean);
+  }
+  else if (has.configure.length) {
+    return [
+      /^install/,
+      /^configure/
+    ].map(function (re) {
+      return scripts
+        .filter(function (s) { return re.test(s); })[0];
+    }).filter(Boolean);
+  }
+
+  return scripts;
 };
 
 //
@@ -117,14 +161,14 @@ exports.run = function (script, runlist, callback) {
       function maybeLocalizeRunlist(installed_, next) {
         installed = installed_;
 
-        return script === 'install' && quill.argv.force
+        return /^install/.test(script) && quill.argv.force
           ? next(null, systems)
           : next(null, composer.localizeRunlist(systems, installed));
       },
       composer.installed.add
     ], function (err) {
       return !err
-        ? runAll(composer.expandRunlist(script, systems, installed));
+        ? runAll(composer.expandRunlist(script, systems, installed))
         : callback(err);
     });
   }
@@ -151,7 +195,7 @@ exports.run = function (script, runlist, callback) {
     });
   }
 
-  if (script === 'install' && quill.argv.force) {
+  if (/^install/.test(script) && quill.argv.force) {
     //
     // Special case: when we're installing system which is already installed,
     // run uninstall script for the installed version first.
@@ -161,14 +205,29 @@ exports.run = function (script, runlist, callback) {
         return cacheSystems();
       }
 
-      async.forEachSeries(Object.keys(installed), function (system, next) {
-        //
-        // Remark: what to do when `uninstall` script fails? Ignore and continue
-        // or stop?
-        //
-        return ~runlist.indexOf(system)
-          ? exports.runOne('uninstall', installed[system].system, next)
-          : next();
+      async.forEachSeries(Object.keys(installed), function (name, next) {
+        if (!~runlist.indexOf(name)) {
+          return next();
+        }
+
+        var system = installed[name].system,
+            uninstall;
+
+        uninstall = system.scripts && system.scripts.filter(function (script) {
+          return /^uninstall/.test(script);
+        })[0];
+
+        if (!uninstall) {
+          return next();
+        }
+
+        composer.config.getConfig(system, function (err, config) {
+          //
+          // Remark: what to do when `uninstall` script fails? Ignore and continue
+          // or stop?
+          //
+          exports.runOne(uninstall, system, config, next);
+        });
       }, function () {
         composer.installed.remove(runlist, cacheSystems);
       });
@@ -187,11 +246,6 @@ exports.run = function (script, runlist, callback) {
 // `system` on the current machine.
 //
 exports.runScripts = function (system, callback) {
-  var responded = false,
-      config,
-      target,
-      child;
-
   //
   // Get the configuration for the specified system and then
   // run all scripts in `system.scripts`.
@@ -205,9 +259,9 @@ exports.runScripts = function (system, callback) {
     }
 
     async.forEachSeries(
-      system.scripts,
+      sortScripts(system.scripts),
       function run(script, next) {
-        exports.run(script, system, config, next);
+        exports.runOne(script, system, config, next);
       },
       callback
     );
@@ -225,6 +279,9 @@ exports.runScripts = function (system, callback) {
 // the given `config` on the current machine.
 //
 exports.runOne = function (script, system, config, callback) {
+  var responded = false,
+      child;
+
   //
   // ### function run(err)
   // Helper function which executes the specified script
@@ -235,7 +292,8 @@ exports.runOne = function (script, system, config, callback) {
       return callback(err);
     }
 
-    var target = path.join(system.path, 'scripts', script);
+    var target = path.join(system.path, 'scripts', script),
+        action = path.basename(script, path.extname(script));
 
     //
     // Read all the files from the system's `scripts` directory, fetch the
@@ -261,7 +319,7 @@ exports.runOne = function (script, system, config, callback) {
       system.history = system.history || {};
       system.history[start] = {
         version: system.version,
-        action: script,
+        action: action,
         time: 'start'
       };
 
@@ -293,7 +351,7 @@ exports.runOne = function (script, system, config, callback) {
         var end = (new Date()).toISOString();
         system.history[end] = {
           version: system.version,
-          action: script,
+          action: action,
           time: 'end'
         };
 
@@ -327,7 +385,7 @@ exports.runOne = function (script, system, config, callback) {
   // If the `script` is not "configure" then just
   // run the script.
   //
-  if (script !== 'configure' || quill.config.get('template') === false) {
+  if (!/^configure/.test(script) || quill.config.get('template') === false) {
     return run();
   }
 

--- a/lib/quill/composer/remote.js
+++ b/lib/quill/composer/remote.js
@@ -90,15 +90,6 @@ exports.download = function (options, callback) {
       return callback(err);
     }
     
-    runlist = runlist.map(function (system) {
-      var parts = system.split('@');
-      
-      return {
-        name: parts[0],
-        version: parts[1]
-      };
-    });
-    
     async.forEach(runlist, downloadOne, function (err) {
       return err ? callback(err) : callback(null, runlist);
     });

--- a/test/composer/config-test.js
+++ b/test/composer/config-test.js
@@ -57,11 +57,11 @@ vows.describe('quill/composer/config').addBatch(
         //
         for (i = 0; i < 2; i++) {
           api
-            .get('/config/test-config')
+            .get('/config/missing-config')
             .reply(200, {
               config: {
                 resource: 'Config',
-                name: 'test-config',
+                name: 'missing-config',
                 settings: {
                   foo: 'bazz',
                   baz: 'foo'
@@ -70,11 +70,11 @@ vows.describe('quill/composer/config').addBatch(
             });
         }
 
-        quill.argv.config = ['test-config'];
+        quill.argv.config = ['missing-config'];
         helpers.cleanInstalled(['config']);
         mock.systems.local(api, callback);
       },
-      'should output correct data',
+      'should respond with the correct error',
       function (err, _) {
         assert.isObject(err);
         assert.match(err.message, /Missing configuration value: nested/);

--- a/test/composer/lifecycle-order-test.js
+++ b/test/composer/lifecycle-order-test.js
@@ -37,7 +37,6 @@ vows.describe('quill/composer/lifecycle/order').addBatch(
       },
       'should install the system correctly': function (err, _) {
         assert.isNull(err);
-
         assert.equal(this.data, [
           'Installing order',
           'Configuring order',

--- a/test/composer/lifecycle-os-deps-test.js
+++ b/test/composer/lifecycle-os-deps-test.js
@@ -38,7 +38,7 @@ vows.describe('quill/composer/lifecycle/os-deps').addBatch(
           });
         });
 
-        helpers.cleanInstalled(['ubuntu-dep']);
+        helpers.cleanInstalled(['fixture-one', 'ubuntu-dep']);
         mock.systems.local(api, function () {
           quill.composer.run('install', 'ubuntu-dep', self.callback);
         });

--- a/test/composer/lifecycle-reinstall-test.js
+++ b/test/composer/lifecycle-reinstall-test.js
@@ -20,8 +20,6 @@ vows.describe('quill/composer/lifecycle/reinstall').addBatch(
   'When using `quill.composer`': {
     'the `run()` method called for the first time': {
       topic: function () {
-        quill.argv.force = true;
-
         var api = nock('http://api.testquill.com'),
             self = this;
 
@@ -48,6 +46,7 @@ vows.describe('quill/composer/lifecycle/reinstall').addBatch(
         var api = nock('http://api.testquill.com'),
             self = this;
 
+        quill.argv.force = true;
         self.data = '';
         quill.on(['run', '*', 'stdout'], function (system, data) {
           self.data += data.toString();

--- a/test/composer/lifecycle-test.js
+++ b/test/composer/lifecycle-test.js
@@ -53,12 +53,17 @@ vows.describe('quill/composer/lifecycle').addBatch(
           that.data = data.toString();
         })
         
-        quill.composer.runOne('install', {
-          name: 'fixture-one',
-          version: '0.0.0',
-          history: {},
-          path: path.join(systemsDir, 'fixture-one')
-        }, this.callback);
+        quill.composer.runOne(
+          'install.sh',
+          {
+            name: 'fixture-one',
+            version: '0.0.0',
+            history: {},
+            path: path.join(systemsDir, 'fixture-one')
+          },
+          {},
+          this.callback
+        );
       },
       "should run the target script successfully": function (err, _) {
         assert.isNull(err);

--- a/test/helpers/macros.js
+++ b/test/helpers/macros.js
@@ -175,7 +175,12 @@ exports.shouldMakeRunlist = function (args, os) {
     },
     "should respond with the correct runlist": function (err, actual) {
       assert.isNull(err);
-      assert.deepEqual(actual, list);
+      assert.deepEqual(
+        actual.map(function (system) {
+          return [system.name, system.version].join('@');
+        }),
+        list
+      );
     }
   }
 };

--- a/test/helpers/mock.js
+++ b/test/helpers/mock.js
@@ -10,6 +10,7 @@ var fs = require('fs'),
     common = require('flatiron').common,
     async = common.async,
     nock = require('nock'),
+    composer = require('../../lib/quill/composer'),
     systems = require('../fixtures/systems');
 
 var mock = module.exports;
@@ -60,13 +61,12 @@ mock.systems.local = function (api, callback) {
         return next();
       }
       
-      fs.readFile(path.join(dir, 'system.json'), 'utf8', function (err, data) {
+      composer.readJson(dir, function (err, system) {
         if (err) {
           return next(err);
         }
         
-        var system = JSON.parse(data),
-            version = common.clone(system);
+        var version = common.clone(system);
         
         system.versions = {};
         system.versions[system.version] = version;


### PR DESCRIPTION
Directly responsible for #48. For example if you've got a simple dependency tree:

``` js
  {
    "name": "depends-on-foo",
    "dependencies": {
      "foo": "0.x.x"
    }
  }
```

And you run:

```
  quill install depends-on-foo
```

This installs the systems and executes the `install` lifecycle-action scripts as expected. But if you then want to run the `update` lifecycle-action for `depends-on-foo` it is _automatically skipped because it is already installed._

```
quill update depends-on-foo
warn:    Skipping installed dependency: depends-on-foo
```

**This pull-request fixes that behavior:**

```
quill update depends-on-foo
info:    Already installed: foo
info:    Already installed: depends-on-foo
info:    Already executed lifecycle action install for foo
info:    Already executed lifecycle action install for depends-on-foo
info:    Executing /.quill/installed/depends-on-foo/<version>/scripts/update.sh
```
